### PR TITLE
build(dist): create dist folder

### DIFF
--- a/package.dist.json
+++ b/package.dist.json
@@ -1,0 +1,21 @@
+{
+	"name": "@mdi/svg",
+	"version": "7.4.47",
+	"description": "Material Design Icons SVG",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Templarian/MaterialDesign-SVG.git"
+	},
+	"keywords": [
+		"material",
+		"design",
+		"icons",
+		"mdi"
+	],
+	"author": "Austin Andrews",
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/Templarian/MaterialDesign/issues"
+	},
+	"homepage": "https://materialdesignicons.com/"
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
 	"version": "7.4.47",
 	"description": "Material Design Icons SVG",
 	"scripts": {
+		"prebuild": "rm -rf dist/",
 		"build": "ts-node ./build.ts",
+		"postbuild": "mkdir -p dist && cp -r ./svg dist && cp meta.json README.md package.dist.json dist/ && mv dist/package.dist.json dist/package.json",
 		"verify": "node scripts/verify.js",
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"format": "prettier . --write",


### PR DESCRIPTION
in oder not to reinstall packages

now we can reference /dist folder with new `package.json` without referensing additional libs

Reference dist:
* before `    "@mdi/svg": "file:./custom-npms/nc-mdi-svg",`
* after `    "@mdi/svg": "file:./custom-npms/nc-mdi-svg/dist",`
